### PR TITLE
Fixed issue with /tmp/pritunl permissions which allows command execution as root

### DIFF
--- a/service/utils/utils.go
+++ b/service/utils/utils.go
@@ -791,7 +791,12 @@ func GetTempDir() (pth string, err error) {
 		err = os.MkdirAll(pth, 0755)
 	} else {
 		pth = filepath.Join(string(filepath.Separator), "tmp", "pritunl")
-		err = os.MkdirAll(pth, 0700)
+		if _, err := os.Stat(pth); !os.IsNotExist(err) {
+			os.Chown(pth, os.Getuid(), os.Getuid())
+			os.Chmod(pth, 0700)
+		} else {
+			err = os.MkdirAll(pth, 0700)
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
- When pritunl service starts a vpn connection it stores some scripts and auth files in /tmp/pritunl. 
- If /tmp/pritunl does not exist, it creates it and sets its permissions to 700
- The vulnerability happens when the pritunl directory does not exist and a non-root user creates it. As it is the owner of that directory, the user can remove files, even if they are owned by root, and create the file with the same name.
- By doing this, a user can remove a -down.sh script and create a new one with the same name with any command
- This script will get executed when the vpn gets disconnected

This PR makes sure that pritunl service changes the permissions of the directory even if it exists, and changes the ownership to root.