### PR TITLE
fixes panic on Linux

### DIFF
--- a/service/profile/profile.go
+++ b/service/profile/profile.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -534,19 +535,44 @@ func (p *Profile) parseLine(line string) {
 			p.update()
 		}
 	} else if strings.Contains(line, "ip addr add dev") {
-		sIndex := strings.Index(line, "ip addr add dev") + 16
-		eIndex := strings.Index(line, "broadcast")
-		line = line[sIndex:eIndex]
-		split := strings.Split(line, " ")
-
-		if len(split) > 1 {
-			split := strings.Split(split[1], "/")
-			if len(split) > 1 {
-				p.ClientAddr = split[0]
-				p.update()
-			}
+		clientAddr := ""
+		switch {
+		case strings.Contains(line, "peer"):
+			clientAddr = parsePeer(line)
+		default:
+			clientAddr = parseBroadcast(line)
+		}
+		if clientAddr != "" {
+			p.update()
 		}
 	}
+}
+
+func parsePeer(line string) string {
+	// /sbin/ip addr add dev tun0 local 10.240.0.6 peer 10.240.0.5
+	re := regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
+
+	submatchall := re.FindAllString(line, -1)
+	if len(submatchall) == 0 {
+		return ""
+	}
+	return submatchall[0]
+}
+
+func parseBroadcast(line string) string {
+	sIndex := strings.Index(line, "ip addr add dev") + 16
+	eIndex := strings.Index(line, "broadcast")
+	line = line[sIndex:eIndex]
+	split := strings.Split(line, " ")
+
+	if len(split) > 1 {
+		split := strings.Split(split[1], "/")
+		if len(split) > 1 {
+			return split[0]
+		}
+	}
+
+	return ""
 }
 
 func (p *Profile) clearStatus(start time.Time) {

--- a/service/profile/profile.go
+++ b/service/profile/profile.go
@@ -543,20 +543,23 @@ func (p *Profile) parseLine(line string) {
 			clientAddr = parseBroadcast(line)
 		}
 		if clientAddr != "" {
+			p.ClientAddr = clientAddr
 			p.update()
 		}
 	}
 }
 
 func parsePeer(line string) string {
-	// /sbin/ip addr add dev tun0 local 10.240.0.6 peer 10.240.0.5
+	// Example line:
+	// Thu Nov 14 13:08:41 2019 /sbin/ip addr add dev tun0 local 10.240.0.6 peer 10.240.0.5
 	re := regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
+	ipList := re.FindAllString(line, -1)
 
-	submatchall := re.FindAllString(line, -1)
-	if len(submatchall) == 0 {
+	if len(ipList) == 0 {
 		return ""
 	}
-	return submatchall[0]
+
+	return ipList[0]
 }
 
 func parseBroadcast(line string) string {


### PR DESCRIPTION
Pritunl Client panics while connecting a OpenVPN server installed by [stable helm repositroy](https://github.com/helm/charts/tree/master/stable/openvpn). We see a log line like this:

`/sbin/ip addr add dev tun0 local 10.240.0.6 peer 10.240.0.5`

This causes a panic in profile.go, which is posted below. I made a change to handle this gracefully. This is tested on Ubuntu 18.04 and confirmed that is working.

```
panic: runtime error: slice bounds out of range [:-1] [recovered]
        panic: runtime error: slice bounds out of range [:-1]

goroutine 49 [running]:
github.com/pritunl/pritunl-client-electron/service/profile.(*Profile).Start.func3.1()
        /go/src/github.com/pritunl/pritunl-client-electron/service/profile/profile.go:887 +0x24b
panic(0xa49500, 0xc000286520)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/pritunl/pritunl-client-electron/service/profile.(*Profile).parseLine(0xc00025e000, 0xc000075980, 0x54)
        /go/src/github.com/pritunl/pritunl-client-electron/service/profile/profile.go:539 +0xc20
github.com/pritunl/pritunl-client-electron/service/profile.(*Profile).Start.func3(0xc0001e5ad0, 0xc00024cba0, 0xc00025e000)
        /go/src/github.com/pritunl/pritunl-client-electron/service/profile/profile.go:899 +0xa9
created by github.com/pritunl/pritunl-client-electron/service/profile.(*Profile).Start
        /go/src/github.com/pritunl/pritunl-client-electron/service/profile/profile.go:879 +0xf41

```