### PR TITLE
This fixes a problem where nothing happens after preConnectMsg

### DIFF
--- a/client/www/js/profileView.js
+++ b/client/www/js/profileView.js
@@ -420,15 +420,14 @@ var renderProfile = function(index, prfl) {
             message: 'Connecting to ' + data.name,
             detail: preConnectMsg,
             buttons: ['Disconnect', 'Connect'],
-          },
-          function(resp) {
-            if (resp === 1) {
-              prflConnect();
-            } else {
-              closeMenu($profile);
-            }
-          },
-        );
+          }
+        ).then(function(resp) {
+          if (resp.response === 1) {
+            prflConnect();
+          } else {
+            closeMenu($profile);
+          }
+        });
       } else {
         prflConnect();
       }


### PR DESCRIPTION
Seems that the electron `showMessageBox` call changed to return Promise (https://electronjs.org/docs/api/dialog?q=%2F#dialogshowmessageboxbrowserwindow-options)