### PR TITLE
Add tray icon support to linux

### DIFF
--- a/client/www/main.js
+++ b/client/www/main.js
@@ -150,8 +150,7 @@ var checkService = function(callback) {
 
 app.on('window-all-closed', function() {
   config.reload(function() {
-    if (process.platform === 'linux' ||
-        config.settings.disable_tray_icon || !tray) {
+    if (config.settings.disable_tray_icon || !tray) {
       app.quit();
     } else {
       if (app.dock) {
@@ -239,7 +238,7 @@ var openMainWin = function() {
     main.maximizedPrev = null;
 
     main.on('closed', function() {
-      if (process.platform === 'linux' || !app.dock) {
+      if (process.platform !== 'linux' && !app.dock) {
         app.quit();
       }
       main = null;
@@ -374,14 +373,12 @@ app.on('ready', function() {
 
       if (!noMain) {
         openMainWin();
-      } else if (process.platform === 'linux' ||
-          config.settings.disable_tray_icon) {
+      } else if (config.settings.disable_tray_icon) {
         app.quit();
         return;
       }
 
-      if (process.platform !== 'linux' &&
-          !config.settings.disable_tray_icon) {
+      if (!config.settings.disable_tray_icon) {
         tray = new Tray(disconnTray);
         tray.on('click', function() {
           openMainWin();
@@ -459,6 +456,10 @@ app.on('ready', function() {
         }
       ]);
       Menu.setApplicationMenu(appMenu);
+      if (tray) {
+        // required on linux 
+        tray.setContextMenu(appMenu);
+      }
 
       profile.getProfiles(function(err, prfls) {
         if (err) {


### PR DESCRIPTION
In linux (at least Ubuntu 18.04, 19.10 and 20.04) there are no linux tray icon, 
making it difficult to identify the connection status.

This PR add support to tray icon ensuring the linux plataform limitations is considered
https://www.electronjs.org/docs/api/tray