### PR TITLE
[WIP] Fix broken systemd-resolved up script which fails to run on Fedora

### DIFF
--- a/service/profile/scripts.go
+++ b/service/profile/scripts.go
@@ -265,7 +265,7 @@ get_link_info() {
   shift
 
   link=''
-  link="$(ip link show dev "$dev")" || return $?
+  link="$(/sbin/ip link show dev "$dev")" || return $?
 
   echo "$dev" "${link%%:*}"
 }


### PR DESCRIPTION
This pull request fixes an issue with pritunl not working on Fedora when systemd-resolved is used.

## Background, Context

When trying to use pritunl on Fedora (32, 33) with systemd-resolved configured, you receive this error:

```bash
Wed Nov 18 11:01:24 2020 /sbin/ip link set dev tun0 up mtu 1500
Wed Nov 18 11:01:24 2020 /sbin/ip addr add dev tun0 10.225.248.51/22 broadcast 10.225.251.255
Wed Nov 18 11:01:24 2020 /tmp/pritunl/55da6b60e49a8f65f4dd5337decc879c-up.sh tun0 1500 1553 10.225.248.51 255.255.252.0 init
/tmp/pritunl/55da6b60e49a8f65f4dd5337decc879c-up.sh: line 61: ip: command not found
```

The issue is that systemd resolved up script is not using full path to the ``ip`` binary like the other scripts, so it fails.

Due to how this code is implemented (script is written to a random temporary file), I can't manually edit / monkey patch that script. And due to how that openvpn is executed, I can't manipulate ``PATH`` / environment for that command run either.

## Proposed Fix

I believe using full path to ``ip`` binary should be fine, especially since it's also used in other scripts.

Another possible workaround would be to disable systemd-resolved, but usually people have specific reasons to use it (DNS over TLS, DNSSEC) and it's also the default on Fedora 33.