### PR TITLE
Click on tray icon should bring app to foreground

### DIFF
--- a/client/www/main.js
+++ b/client/www/main.js
@@ -180,7 +180,7 @@ app.on('quit', function() {
 
 var openMainWin = function() {
   if (main) {
-    main.focus();
+    main.show();
     return;
   }
 


### PR DESCRIPTION
Usually if I want to check my connection status or activate my 2FA device to start a connection, I click on the tray icon to open the app.
I recently found myself confused by this no longer working as I expected. 
Clicking the tray icon will only focus the app if the window is closed, but not if the window is open in the background. 

Looking at the docs for [BrowserWindow](https://www.electronjs.org/docs/api/browser-window#winshow) I found that there is another api that will bring focus to the window even when it's in the background. 

I've only tested this on MacOS 11.1.