### PR TITLE
Missing LaunchAgents/com.pritunl.client.plist on install OSX

### DIFF
--- a/tools/install_macos.sh
+++ b/tools/install_macos.sh
@@ -40,6 +40,10 @@ cp service/service build/macos/Applications/Pritunl.app/Contents/Resources/pritu
 mkdir -p build/macos/Library/LaunchDaemons
 cp service_macos/com.pritunl.service.plist build/macos/Library/LaunchDaemons
 
+# Client Agent
+mkdir -p build/macos/Library/LaunchAgents
+cp service_macos/com.pritunl.client.plist build/macos/Library/LaunchAgents
+
 # Openvpn
 cp openvpn_macos/openvpn build/macos/Applications/Pritunl.app/Contents/Resources/pritunl-openvpn
 cp openvpn_macos/openvpn10 build/macos/Applications/Pritunl.app/Contents/Resources/pritunl-openvpn10


### PR DESCRIPTION
Hi,

I tried to install from the source repo this morning but I got this error : 
```
###################################################
Preinstall: Stopping pritunl service...
###################################################
###################################################
Installing...
###################################################
cp: build/macos/Library/LaunchAgents/com.pritunl.client.plist: No such file or directory
```

I noticed those two lines were missing. Intentional or mistake?

Now it works like a charm.  