### PR TITLE
Update wireguard-tools path for Mac M1

### DIFF
--- a/service/profile/profile.go
+++ b/service/profile/profile.go
@@ -156,6 +156,7 @@ type Profile struct {
 	authFailed         bool               `json:"-"`
 	waiters            []chan bool        `json:"-"`
 	remPaths           []string           `json:"-"`
+	bashPath           string             `json:"-"`
 	wgPath             string             `json:"-"`
 	wgQuickPath        string             `json:"-"`
 	wgConfPth          string             `json:"-"`
@@ -1013,7 +1014,7 @@ func (p *Profile) clearWgMac() {
 			[]string{
 				"is not a",
 			},
-			"/usr/local/bin/bash",
+			p.bashPath,
 			p.wgQuickPath,
 			"down", p.Iface,
 		)
@@ -1144,6 +1145,7 @@ func (p *Profile) Init() {
 	p.Id = utils.FilterStr(p.Id)
 	p.stateLock = sync.Mutex{}
 	p.waiters = []chan bool{}
+	p.bashPath = GetBashPath()
 	p.wgPath = GetWgPath()
 	p.wgQuickPath = GetWgQuickPath()
 }
@@ -2387,7 +2389,7 @@ func (p *Profile) confWgMac() (err error) {
 	output := ""
 	for i := 0; i < 3; i++ {
 		_, _ = utils.ExecCombinedOutput(
-			"/usr/local/bin/bash", p.wgQuickPath, "down", p.Iface,
+			p.bashPath, p.wgQuickPath, "down", p.Iface,
 		)
 
 		if i == 0 {
@@ -2398,7 +2400,7 @@ func (p *Profile) confWgMac() (err error) {
 
 		output, err = utils.ExecCombinedOutputLogged(
 			nil,
-			"/usr/local/bin/bash",
+			p.bashPath,
 			p.wgQuickPath,
 			"up", p.Iface,
 		)

--- a/service/profile/utils.go
+++ b/service/profile/utils.go
@@ -41,6 +41,11 @@ func GetWgPath() string {
 			return path
 		}
 
+		path, _ = exec.LookPath("/opt/homebrew/bin/wg")
+		if path != "" {
+			return path
+		}
+
 		break
 	case "linux":
 		path, _ := exec.LookPath("wg")
@@ -72,6 +77,11 @@ func GetWgQuickPath() string {
 		}
 
 		path, _ = exec.LookPath("/usr/local/bin/wg-quick")
+		if path != "" {
+			return path
+		}
+
+		path, _ = exec.LookPath("/opt/homebrew/bin/wg-quick")
 		if path != "" {
 			return path
 		}
@@ -168,6 +178,26 @@ func getOpenvpnDir() (pth string) {
 	}
 
 	return
+}
+
+func GetBashPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		switch runtime.GOARCH {
+		case "arm64":
+			return "/opt/homebrew/bin/bash"
+		default:
+			return "/usr/local/bin/bash"
+		}
+		break
+	case "linux":
+		break
+	case "windows":
+		break
+	default:
+		panic("handlers: Not implemented")
+	}
+	return ""
 }
 
 func Clean() (err error) {


### PR DESCRIPTION
In MacOS for M1, homebrew path is located under /opt/homebrew. So we need to update path for wg and wg-quick.