### PR TITLE
allow retry of things like TCP Reset and other odd network behaviors

### DIFF
--- a/service/profile/profile.go
+++ b/service/profile/profile.go
@@ -2079,6 +2079,7 @@ func (p *Profile) pingWg() (wgData *WgPingData, retry bool, err error) {
 		err = &errortypes.RequestError{
 			errors.Wrap(err, "profile: Request put error"),
 		}
+		retry = true
 		return
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
We have a client on very flaky internet where the connection occasionally gets a tcp reset. It'd be nice to enable retries if y'all would be ok with that.