### PR TITLE
Changing log file name

### DIFF
--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -91,7 +91,7 @@ func GetLogPath() (pth string) {
 			panic(err)
 		}
 
-		pth = filepath.Join(pth, "pritunl.log")
+		pth = filepath.Join(pth, "pritunl-client.log")
 
 		return
 	}
@@ -108,11 +108,11 @@ func GetLogPath() (pth string) {
 			panic(err)
 		}
 
-		pth = filepath.Join(pth, "pritunl.log")
+		pth = filepath.Join(pth, "pritunl-client.log")
 		break
 	case "linux", "darwin":
 		pth = filepath.Join(string(filepath.Separator),
-			"var", "log", "pritunl.log")
+			"var", "log", "pritunl-client.log")
 		break
 	default:
 		panic("profile: Not implemented")

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -133,7 +133,7 @@ func GetLogPath2() (pth string) {
 			panic(err)
 		}
 
-		pth = filepath.Join(pth, "pritunl.log.1")
+		pth = filepath.Join(pth, "pritunl-client.log.1")
 
 		return
 	}
@@ -150,15 +150,15 @@ func GetLogPath2() (pth string) {
 			panic(err)
 		}
 
-		pth = filepath.Join(pth, "pritunl.log.1")
+		pth = filepath.Join(pth, "pritunl-client.log.1")
 		break
 	case "darwin":
 		pth = filepath.Join(string(os.PathSeparator), "Applications",
-			"Pritunl.app", "Contents", "Resources", "pritunl.log.1")
+			"Pritunl.app", "Contents", "Resources", "pritunl-client.log.1")
 		break
 	case "linux":
 		pth = filepath.Join(string(filepath.Separator),
-			"var", "log", "pritunl.log.1")
+			"var", "log", "pritunl-client.log.1")
 		break
 	default:
 		panic("profile: Not implemented")


### PR DESCRIPTION
In RHEL rpm install, installing both `pritunl` and `pritunl-client` fails because the log files are the same.