### PR TITLE
Restore Linux tray icons and cleanup

### DIFF
--- a/client/www/css/main.css
+++ b/client/www/css/main.css
@@ -469,12 +469,6 @@ input:active {
 .main-menu.show {
   height: 204px;
 }
-.main-menu.linux.show {
-  height: 170px;
-}
-.main-menu.linux .tray-icon {
-  display: none;
-}
 .main-menu .btn {
   color: #fff;
   width: 190px;

--- a/client/www/js/init.js
+++ b/client/www/js/init.js
@@ -160,9 +160,6 @@ var closeServiceEditor = function() {
 };
 
 config.onReady(function() {
-  if (process.platform === 'linux') {
-    $('.main-menu').addClass('linux');
-  }
   $('.auto-reconnect').text('Auto Reconnect ' +
     (!config.settings.disable_reconnect ? 'On' : 'Off'));
   $('.tray-icon').text('Tray Icon ' +

--- a/client/www/main.js
+++ b/client/www/main.js
@@ -153,8 +153,7 @@ var checkService = function(callback) {
 
 app.on('window-all-closed', function() {
   config.reload(function() {
-    if (process.platform === 'linux' ||
-        config.settings.disable_tray_icon || !tray) {
+    if (config.settings.disable_tray_icon || !tray) {
       app.quit();
     } else {
       if (app.dock) {
@@ -244,8 +243,7 @@ var openMainWin = function() {
     main.maximizedPrev = null;
 
     main.on('closed', function() {
-      if (process.platform === 'linux' ||
-          config.settings.disable_tray_icon || !tray) {
+      if (config.settings.disable_tray_icon || !tray) {
         app.quit();
       }
       main = null;
@@ -398,14 +396,12 @@ app.on('ready', function() {
 
       if (!noMain) {
         openMainWin();
-      } else if (process.platform === 'linux' ||
-          config.settings.disable_tray_icon) {
+      } else if (config.settings.disable_tray_icon) {
         app.quit();
         return;
       }
 
-      if (process.platform !== 'linux' &&
-          !config.settings.disable_tray_icon) {
+      if (!config.settings.disable_tray_icon) {
         tray = new Tray(disconnTray);
         tray.on('click', function() {
           openMainWin();


### PR DESCRIPTION
Hi,

Some of the users that I work with reported, that the lack of tray icons is confusing on Linux from UX perspective.
Apps like Slack, Discord, Rocketchat work correctly and present a tray icon even on GNOME (with appindicator extension).

I've tested my changes on:
- Fedora 35
- ArchLinux
- Kubuntu 21.04
- Ubuntu 20.04

Following scenarios were tested:
- trying to launch Pritunl client without appindicator extension/libs
- connecting/disconnecting from VPN
- switching tray icons on/off and restarting client
- clicking on tray icons in various states

It seems that bulk of the changes, that removed the tray icon support on Linux were introduced here:
https://github.com/pritunl/pritunl-client-electron/commit/a9e96cfb0e1e59b81bc495063dd0f0ffe895f28d

I don't know if blocking Linux from using Tray icons is still necessary as they are working correctly across the board, if there are some edge cases that I'm missing, maybe it's a good idea to refine the conditions here.

On GNOME, `gnome-shell-extension-appindicator` must be installed and gnome shell needs to be restarted.
On KDE, tray icons work out of the box.
If there's no appindicator support on the system, the client functions just fine, but the tray icon is not present.

Overall, I think it's better for user experience as it's pretty easy to install some additional dependency than tinker with application source code. (Maybe it's possible to add some information regarding the GNOME plugin or add it as dependency on various platforms?)

I'm willing to do some more digging/testing if necessary, I'd really like to get tray icon support ironed out :)

Have a lovely day!