### PR TITLE
Add plain format flag for list sub-command

### DIFF
--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/olekukonko/tablewriter"
+	"github.com/pritunl/pritunl-client-electron/cli/service"
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,14 @@ var ListCmd = &cobra.Command{
 			return
 		}
 
-		table := tablewriter.NewWriter(os.Stdout)
+		var table service.Printable
+		if doPlainOutput {
+			table = service.NewPlainWriter(os.Stdout)
+		} else {
+			table = tablewriter.NewWriter(os.Stdout)
+			table.SetBorder(true)
+		}
+
 		table.SetHeader([]string{
 			"ID",
 			"Name",
@@ -28,7 +36,6 @@ var ListCmd = &cobra.Command{
 			"Server Address",
 			"Client Address",
 		})
-		table.SetBorder(true)
 
 		for _, sprfl := range sprfls {
 			if sprfl.Profile != nil {

--- a/cli/cmd/var.go
+++ b/cli/cmd/var.go
@@ -4,6 +4,7 @@ var (
 	mode           string
 	password       string
 	passwordPrompt bool
+	doPlainOutput  bool
 )
 
 func init() {
@@ -27,5 +28,12 @@ func init() {
 		"r",
 		false,
 		"Prompt for VPN password",
+	)
+	ListCmd.Flags().BoolVarP(
+		&doPlainOutput,
+		"plain",
+		"1",
+		false,
+		"No fancy table formatting",
 	)
 }

--- a/cli/service/table.go
+++ b/cli/service/table.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+const fieldSeparator = ","
+
+type PlainTable struct {
+	writer  io.Writer
+	headers []string
+	lines   [][]string
+}
+
+type Printable interface {
+	SetHeader([]string)
+	SetBorder(bool)
+	Append([]string)
+	Render()
+}
+
+func NewPlainWriter(writer io.Writer) *PlainTable {
+	return &PlainTable{
+		writer:  writer,
+		headers: make([]string, 0),
+		lines:   make([][]string, 0),
+	}
+}
+
+func (t *PlainTable) SetHeader(keys []string) {
+	t.headers = keys
+}
+
+func (t *PlainTable) SetBorder(bool) {
+	// just to conform with Printable interface
+}
+
+func (t *PlainTable) Append(values []string) {
+	t.lines = append(t.lines, values)
+}
+
+func (t *PlainTable) Render() {
+	for _, line := range t.lines {
+		fmt.Fprintln(t.writer, strings.Join(line, fieldSeparator))
+	}
+}


### PR DESCRIPTION
This change will allow plain old CLI tools (like grep and AWK) to work correctly in all cases.

The `tablewriter` library is too smart as it checks width of the terminal and chops cells' content into multiple lines (especially true for profile names) breaking line-oriented command line tools like grep.

Alternative is to use JSON or another machine readable format like in [this fork](https://github.com/noahwaldner/pritunl-client-electron/commit/90a4d900db6d2d42b49926ce58dcfe4e30d701c1).