### PR TITLE
Less unnecessary panics on user facing CLI, please

### DIFF
--- a/cli/cmd/add.go
+++ b/cli/cmd/add.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"strings"
 
-	"github.com/dropbox/godropbox/errors"
-	"github.com/pritunl/pritunl-client-electron/cli/errortypes"
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/spf13/cobra"
 )
@@ -14,10 +12,7 @@ var AddCmd = &cobra.Command{
 	Short: "Add profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := errortypes.NotFoundError{
-				errors.New("cmd: Missing profile URI or path"),
-			}
-			panic(err)
+			cobra.CheckErr("cmd: Missing profile URI or path")
 		}
 
 		path := args[0]
@@ -27,16 +22,10 @@ var AddCmd = &cobra.Command{
 			strings.HasPrefix(path, "pritunls://") {
 
 			err := sprofile.ImportUri(path)
-			if err != nil {
-				panic(err)
-				return
-			}
+			cobra.CheckErr(err)
 		} else {
 			err := sprofile.ImportTar(path)
-			if err != nil {
-				panic(err)
-				return
-			}
+			cobra.CheckErr(err)
 		}
 	},
 }

--- a/cli/cmd/disable.go
+++ b/cli/cmd/disable.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"github.com/dropbox/godropbox/errors"
-	"github.com/pritunl/pritunl-client-electron/cli/errortypes"
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/spf13/cobra"
 )
@@ -12,16 +10,10 @@ var DisableCmd = &cobra.Command{
 	Short: "Disable autostart for profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := errortypes.NotFoundError{
-				errors.New("cmd: Missing profile ID"),
-			}
-			panic(err)
+			cobra.CheckErr("cmd: Missing profile ID")
 		}
 
 		err := sprofile.SetState(args[0], false)
-		if err != nil {
-			panic(err)
-			return
-		}
+		cobra.CheckErr(err)
 	},
 }

--- a/cli/cmd/enable.go
+++ b/cli/cmd/enable.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"github.com/dropbox/godropbox/errors"
-	"github.com/pritunl/pritunl-client-electron/cli/errortypes"
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/spf13/cobra"
 )
@@ -12,16 +10,10 @@ var EnableCmd = &cobra.Command{
 	Short: "Enable autostart for profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := errortypes.NotFoundError{
-				errors.New("cmd: Missing profile ID"),
-			}
-			panic(err)
+			cobra.CheckErr("cmd: Missing profile ID")
 		}
 
 		err := sprofile.SetState(args[0], true)
-		if err != nil {
-			panic(err)
-			return
-		}
+		cobra.CheckErr(err)
 	},
 }

--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -13,10 +13,7 @@ var ListCmd = &cobra.Command{
 	Short: "List profiles",
 	Run: func(cmd *cobra.Command, args []string) {
 		sprfls, err := sprofile.GetAll()
-		if err != nil {
-			panic(err)
-			return
-		}
+		cobra.CheckErr(err)
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader([]string{

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -2,8 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/dropbox/godropbox/errors"
-	"github.com/pritunl/pritunl-client-electron/cli/errortypes"
+
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/spf13/cobra"
 )
@@ -13,21 +12,14 @@ var LogsCmd = &cobra.Command{
 	Short: "Show logs for profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := errortypes.NotFoundError{
-				errors.New("cmd: Missing profile ID"),
-			}
-			panic(err)
+			cobra.CheckErr("cmd: Missing profile ID")
 		}
 
 		sprfl, err := sprofile.Match(args[0])
-		if err != nil {
-			panic(err)
-		}
+		cobra.CheckErr(err)
 
 		data, err := sprfl.GetLogs()
-		if err != nil {
-			panic(err)
-		}
+		cobra.CheckErr(err)
 
 		fmt.Print(data)
 	},

--- a/cli/cmd/remove.go
+++ b/cli/cmd/remove.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"github.com/dropbox/godropbox/errors"
-	"github.com/pritunl/pritunl-client-electron/cli/errortypes"
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/spf13/cobra"
 )
@@ -12,16 +10,10 @@ var RemoveCmd = &cobra.Command{
 	Short: "Remove profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := errortypes.NotFoundError{
-				errors.New("cmd: Missing profile ID"),
-			}
-			panic(err)
+			cobra.CheckErr("cmd: Missing profile ID")
 		}
 
 		err := sprofile.Delete(args[0])
-		if err != nil {
-			panic(err)
-			return
-		}
+		cobra.CheckErr(err)
 	},
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/dropbox/godropbox/errors"
-	"github.com/pritunl/pritunl-client-electron/cli/errortypes"
 	"github.com/spf13/cobra"
 )
 
@@ -12,10 +11,7 @@ var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := cmd.Help()
 		if err != nil {
-			err = &errortypes.ExecError{
-				errors.Wrap(err, "cmd: Failed to execute help command"),
-			}
-			panic(err)
+			cobra.CheckErr(errors.Wrap(err, "cmd: Failed to execute help command"))
 		}
 	},
 }
@@ -23,10 +19,7 @@ var RootCmd = &cobra.Command{
 func Execute() {
 	err := RootCmd.Execute()
 	if err != nil {
-		err = &errortypes.ExecError{
-			errors.Wrap(err, "cmd: Failed to execute root command"),
-		}
-		panic(err)
+		cobra.CheckErr(errors.Wrap(err, "cmd: Failed to execute root command"))
 	}
 }
 

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/pritunl/pritunl-client-electron/cli/terminal"
 	"github.com/spf13/cobra"
@@ -14,20 +11,17 @@ var StartCmd = &cobra.Command{
 	Short: "Start profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Fprintln(os.Stderr, "cmd: Missing profile ID")
-			return
+			cobra.CheckErr("cmd: Missing profile ID")
 		}
 
 		if passwordPrompt {
 			password = terminal.ReadPassword()
 			if password == "" {
-				return
+				cobra.CheckErr("cmd: Password is empty")
 			}
 		}
 
 		err := sprofile.Start(args[0], mode, password)
-		if err != nil {
-			panic(err)
-		}
+		cobra.CheckErr(err)
 	},
 }

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"github.com/dropbox/godropbox/errors"
-	"github.com/pritunl/pritunl-client-electron/cli/errortypes"
 	"github.com/pritunl/pritunl-client-electron/cli/sprofile"
 	"github.com/spf13/cobra"
 )
@@ -12,16 +10,10 @@ var StopCmd = &cobra.Command{
 	Short: "Stop profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := errortypes.NotFoundError{
-				errors.New("cmd: Missing profile ID"),
-			}
-			panic(err)
+			cobra.CheckErr("cmd: Missing profile ID")
 		}
 
 		err := sprofile.Stop(args[0])
-		if err != nil {
-			panic(err)
-			return
-		}
+		cobra.CheckErr(err)
 	},
 }

--- a/cli/cmd/watch.go
+++ b/cli/cmd/watch.go
@@ -10,9 +10,6 @@ var WatchCmd = &cobra.Command{
 	Short: "Watch profiles",
 	Run: func(cmd *cobra.Command, args []string) {
 		err := watch.Init()
-		if err != nil {
-			panic(err)
-			return
-		}
+		cobra.CheckErr(err)
 	},
 }

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -65,11 +65,9 @@ func GetAuthPath() (pth string) {
 	switch runtime.GOOS {
 	case "windows":
 		pth = filepath.Join(GetWinDrive(), "ProgramData", "Pritunl", "auth")
-		break
 	case "linux", "darwin":
 		pth = filepath.Join(string(filepath.Separator),
 			"var", "run", "pritunl.auth")
-		break
 	default:
 		panic("profile: Not implemented")
 	}


### PR DESCRIPTION
This change tries not `panic` when wrong CLI arguments are passed to sub-commands or high level error occurs on the sub-command level. All `panics` deeper in the code body stay untouched.

All appropriate user-facing `panics` replaced with `cobra.CheckErr(err)`, which basically does this: 
```go
if err != nil {
    fmt.Fprintln(os.Stderr, "Error:", err)
    os.Exit(1)  // usually we did not set exit code, a pity...
}
```
instead of old code like this (which is strange by itself): 
```go
if err != nil {
    panic(err)
    return
}
```

`panic` built-in is intended to crash a program. 
An `illegal command line arguments count` is hardly a crash condition. Lets handle the situation in a more civilized maner.
Many such places changed.