### PR TITLE
Add CLI flag to disable DNS watcher.

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -36,6 +36,8 @@ func main() {
 	install := flag.Bool("install", false, "run post install")
 	uninstall := flag.Bool("uninstall", false, "run pre uninstall")
 	devPtr := flag.Bool("dev", false, "development mode")
+	disableWatchPtr := flag.Bool("disableWatch", false, "disable DNS watcher")
+
 	flag.Parse()
 
 	if *install {
@@ -125,7 +127,9 @@ func main() {
 	router := gin.New()
 	handlers.Register(router)
 
-	watch.StartWatch()
+	if !*disableWatchPtr {
+		watch.StartWatch()
+	}
 
 	server := &http.Server{
 		Addr:           "127.0.0.1:9770",


### PR DESCRIPTION
I have this case: I'm connecting to my first VPN via Pritunl and then I'm connecting to the second VPN that gives me some routes and DNS servers. So, I need the ability to *not* reset the DNS setting on change. I think that this is the "developer" setting because I require to understand the consequences of this setting (i.e. you could lose the DNS server in your settings, etc.). So it could be used as an additional CLI flag in the `pritunl-service` utility.