### PR TITLE
Update macos shortcuts for close and exit actions

### DIFF
--- a/client/www/main.js
+++ b/client/www/main.js
@@ -436,7 +436,7 @@ app.on('ready', function() {
             },
             {
               label: 'Close',
-              accelerator: 'CmdOrCtrl+Q',
+              accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+W' : 'CmdOrCtrl+Q',
               role: 'close'
             },
             {
@@ -449,6 +449,7 @@ app.on('ready', function() {
             },
             {
               label: 'Exit',
+              accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+Q' : '',
               click: function() {
                 app.quit();
               }


### PR DESCRIPTION
On MacOS Cmd+Q is used to force quit an application, which should terminate all the processes associated with it.
On the other hand, Cmd+W is typically used to close a single window without killing the entire application.