### PR TITLE
Fix `connected` field being always false

### DIFF
--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -43,6 +43,7 @@ var ListCmd = &cobra.Command{
 						State:           sprfl.FormatedState(),
 						RunState:        sprfl.FormatedRunState(),
 						RegistrationKey: sprfl.RegistrationKey,
+						Connected:       sprfl.Profile.ClientAddr != "",
 						Uptime:          sprfl.Profile.Uptime(),
 						Status:          sprfl.Profile.FormatedTime(),
 						ServerAddress:   sprfl.Profile.ServerAddr,


### PR DESCRIPTION
When asking for `pritunl-client list` with JSON output the `connected` field was always false. That's because it was never mapped to any value.

### Before the change:
`pritunl-client list -f`
```json
[
  {
    "id": "12345<",
    "name": "profile1",
    "state": "Enabled",
    "run_state": "Active",
    "registration_key": "",
    "connected": false, <--- always false
    "uptime": 294,
    "status": "4 mins 54 secs",
    "server_address": "xx.xx.xx.xx",
    "client_address": "xx.xx.xx.xx"
  }
]
```

### After the change:
`pritunl-client list -f`
```json
[
  {
    "id": "12345<",
    "name": "profile1",
    "state": "Enabled",
    "run_state": "Active",
    "registration_key": "",
    "connected": true, <--- now it's true because the client successfully established a connection
    "uptime": 294,
    "status": "4 mins 54 secs",
    "server_address": "xx.xx.xx.xx",
    "client_address": "xx.xx.xx.xx"
  }
]
```