### PR TITLE
fix: add macOS default bash path lookup

### DIFF
--- a/service/profile/utils.go
+++ b/service/profile/utils.go
@@ -210,6 +210,11 @@ func GetBashPath() string {
 			return path
 		}
 
+		path, _ = exec.LookPath("/bin/bash")
+		if path != "" {
+			return path
+		}
+
 		break
 	case "linux":
 		break


### PR DESCRIPTION
**Reason:**

On macOS with the default (system) bash installation, pritunl-client fails to connect using WireGuard.

**Details:**

When bash is not installed via Homebrew, pritunl-client cannot properly use wg-quick because `Profile.bashPath` is empty, resulting in the error: `utils: Failed to exec ''\nexec: no command\`

This small PR adds default system bash location on macOS, which is `/bin/bash`, so Wireguard connection works.