### PR TITLE
Bump Electron to fix macOS 26 performance bug

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -38,7 +38,7 @@
         "@electron/fuses": "1.8.0",
         "@electron/packager": "18.3.6",
         "@electron/rebuild": "4.0.1",
-        "electron": "37.3.1",
+        "electron": "37.6.0",
         "rcedit": "4.0.1",
         "rimraf": "6.0.1",
         "source-map-loader": "5.0.0",
@@ -2298,9 +2298,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "37.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.3.1.tgz",
-      "integrity": "sha512-7DhktRLqhe6OJh/Bo75bTI0puUYEmIwSzMinocgO63mx3MVjtIn2tYMzLmAleNIlud2htkjpsMG2zT4PiTCloA==",
+      "version": "37.6.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.6.0.tgz",
+      "integrity": "sha512-8AANcn6irYQ7cTAJRY7r0CovWckcGCHUniQecyGhw/jJ25vWwitVhF97skF+EyDztiEI6YBoF0G6tx1s37bO3g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "@electron/fuses": "1.8.0",
     "@electron/packager": "18.3.6",
     "@electron/rebuild": "4.0.1",
-    "electron": "37.3.1",
+    "electron": "37.6.0",
     "rcedit": "4.0.1",
     "rimraf": "6.0.1",
     "source-map-loader": "5.0.0",


### PR DESCRIPTION
This is a very basic version bump for the Electron package to the nearest version that fixes the macOS 26 shadow rendering performance bug. See: https://github.com/electron/electron/issues/48311#issuecomment-3332181420

More package version bumps are possible, but those would lead to rebuilding JS files and that's not necessary with this bump.

I've tested this locally with my existing Pritunl service and things work great! Please let me know if I can help out in any other way.