### PR TITLE
feat(cli): add cli command status by profile id

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -33,4 +33,5 @@ func init() {
 	RootCmd.AddCommand(StartCmd)
 	RootCmd.AddCommand(StopCmd)
 	RootCmd.AddCommand(WatchCmd)
+	RootCmd.AddCommand(StatusCmd)
 }

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pritunl/pritunl-client/cli/sprofile"
+	"github.com/spf13/cobra"
+)
+
+var StatusCmd = &cobra.Command{
+	Use:   "status [profile_id]",
+	Short: "Profile status",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cobra.CheckErr("cmd: Missing profile ID")
+		}
+
+		status, err := sprofile.Status(args[0])
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		fmt.Println(status)
+	},
+}

--- a/cli/sprofile/utils.go
+++ b/cli/sprofile/utils.go
@@ -283,6 +283,18 @@ func GetAll() (sprfls Sprofiles, err error) {
 	return
 }
 
+func Status(sprflId string) (string, error) {
+	sprfl, err := Match(sprflId)
+	if err != nil {
+		return "", err
+	}
+	_, status := sprfl.FormatedStatus()
+	if sprfl != nil && sprfl.State && sprfl.Profile != nil && sprfl.Profile.Status == "connected" {
+		return fmt.Sprintf("Connected (online for %s)", status), nil
+	}
+	return status, nil
+}
+
 func PasswordPrompt(sprfl *Sprofile) (pass string, err error) {
 	passModes := set.NewSet()
 


### PR DESCRIPTION
Add a new cli command `status` that returns current VPN formatted status by profile ID. This is useful for a quick status check in automation.

Example:
```
$ ./cli status Dbyx4exUB34i0AjP
Connected (online for 10 secs)
```