### PR TITLE
Abort macOS and Windows builds when the source tree is not at a released version

### DIFF
--- a/tools/build_macos.sh
+++ b/tools/build_macos.sh
@@ -4,13 +4,46 @@ set -e
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 cd ../
 
+# Version is read from the source tree, building before builder.py set-version
+# stamps the package and both Go binaries with the previous release version
+if grep -q "<%= version %>" CHANGES
+then
+    echo "ERROR: unreleased version placeholder in CHANGES, run" \
+        "tools/builder.py set-version before building" >&2
+    exit 1
+fi
+
+APP_VER="$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' client/package.json | head -n1)"
+
+if [ -z "$APP_VER" ]
+then
+    echo "ERROR: unable to read version from client/package.json" >&2
+    exit 1
+fi
+
+for ver in \
+    "$(sed -n 's/^Version \([^ ]*\).*/\1/p' CHANGES | head -n1)" \
+    "$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' client/package-lock.json | head -n1)" \
+    "$(sed -n 's/.*Version = "\([^"]*\)".*/\1/p' service/constants/constants.go | head -n1)" \
+    "$(sed -n 's/.*Version = "\([^"]*\)".*/\1/p' cli/constants/constants.go | head -n1)" \
+    "$(sed -n 's/.*MyAppVersion "\([^"]*\)".*/\1/p' resources_win/setup.iss | head -n1)"
+do
+    if [ "$ver" != "$APP_VER" ]
+    then
+        echo "ERROR: source tree version mismatch, client/package.json has" \
+            "$APP_VER but found $ver, run tools/builder.py set-version" >&2
+        exit 1
+    fi
+done
+
+export APP_VER
+echo "Building version $APP_VER"
+
 rm -rf build
 mkdir -p build/resources
 go clean -cache
 
 node -e "fs=require('fs');f='client/package.json';c=fs.readFileSync(f,'utf8');fs.writeFileSync(f,c.replace(/,\s*\"scripts\": \{[^}]*\}/,''))"
-
-export APP_VER="$(cat client/package.json | grep version | cut -d '"' -f 4)"
 
 # Service
 cd service

--- a/tools/build_win.go
+++ b/tools/build_win.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -14,7 +17,21 @@ const (
 	certSha1      = "c088a20413edc0fdfe17f5905af624c68a33144c"
 	timestampUrl  = "http://timestamp.digicert.com"
 	innoSetupIscc = "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe"
+	changesPath   = "CHANGES"
+	changesVerTag = "<%= version %>"
 )
+
+var versionSources = []struct {
+	path string
+	expr string
+}{
+	{changesPath, `(?m)^Version (\S+)`},
+	{"client/package.json", `"version": *"(.*?)"`},
+	{"client/package-lock.json", `"version": *"(.*?)"`},
+	{"service/constants/constants.go", `Version = "(.*?)"`},
+	{"cli/constants/constants.go", `Version = "(.*?)"`},
+	{"resources_win/setup.iss", `MyAppVersion "(.*?)"`},
+}
 
 var signArgs = []string{
 	"sign",
@@ -110,7 +127,53 @@ func writeFuses(app string) {
 	}
 }
 
+func readVersion(path string, expr string) string {
+	data, err := os.ReadFile(filepath.FromSlash(path))
+	if err != nil {
+		panic(err)
+	}
+
+	match := regexp.MustCompile(expr).FindSubmatch(data)
+	if match == nil {
+		panic("build: unable to read version from " + path)
+	}
+
+	return string(match[1])
+}
+
+// The installer version comes from resources_win/setup.iss and the app version
+// from client/package.json, building before builder.py set-version stamps the
+// installer, the app and both Go binaries with the previous release version
+func checkVersion() {
+	changes, err := os.ReadFile(changesPath)
+	if err != nil {
+		panic(err)
+	}
+
+	if bytes.Contains(changes, []byte(changesVerTag)) {
+		panic("build: unreleased version placeholder in CHANGES, run " +
+			"tools/builder.py set-version before building")
+	}
+
+	version := ""
+	for _, source := range versionSources {
+		ver := readVersion(source.path, source.expr)
+
+		if version == "" {
+			version = ver
+		} else if ver != version {
+			panic("build: source tree version mismatch, expected " +
+				version + " but " + source.path + " has " + ver +
+				", run tools/builder.py set-version")
+		}
+	}
+
+	fmt.Println("Building version " + version)
+}
+
 func main() {
+	checkVersion()
+
 	err := os.RemoveAll("build")
 	if err != nil && !os.IsNotExist(err) {
 		panic(err)


### PR DESCRIPTION
The macOS package on release 1.3.4696.56 reports its version as **1.3.4686.95**, which is the previous release. The code inside the package is correct. Only the version number is wrong.

The build reads the version from the source tree, and this build ran before the version was bumped. Nothing checked for that. This PR adds the check, for macOS and Windows.

**The shipped release still needs fixing separately.** Either cut a new release, or rebuild `Pritunl.pkg.zip`, replace it on the 1.3.4696.56 release, and update the `SHA256` and `SHA512` entries.

## Why it happens

Every version number in the macOS package comes from the source tree. `tools/build_macos.sh` reads `APP_VER` from `client/package.json` and passes it to `pkgbuild` and `productbuild`. `@electron/packager` reads the same field for `Info.plist`. The `pritunl-service` and `pritunl-client` binaries embed their own constants. `tools/builder.py set-version` writes all of them, so a build that starts before that step is stamped with the previous release version.

Windows works the same way. Inno Setup reads the installer version from `resources_win/setup.iss`, which `set-version` also writes. The Windows and Linux assets for 1.3.4696.56 are correct, so the `build_win.go` change here is preventive.

## What this PR does

Both builds now stop before doing any work if `CHANGES` still contains the `<%= version %>` placeholder, which means `set-version` has not run yet, or if the six version locations disagree.

`build_macos.sh` also reads the version more precisely. The old `grep version` matched every line containing "version" and expanded unquoted into `pkgbuild --version`.
